### PR TITLE
Default enable the app

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,6 +6,7 @@
 	<licence>AGPL</licence>
 	<author>Joas Schilling</author>
 	<version>1.0</version>
+	<default_enable/>
 	<namespace>NextcloudAnnouncements</namespace>
 
 	<category>monitoring</category>


### PR DESCRIPTION
While testing the daily build I noticed that this app is not enabled by default. I suppose we should make it that way because otherwise it is kinda useless :see_no_evil:

cc @nickvergessen @karlitschek Thoughts?