### PR TITLE
Fix path

### DIFF
--- a/lib/Cron/Crawler.php
+++ b/lib/Cron/Crawler.php
@@ -157,7 +157,7 @@ class Crawler extends TimedJob  {
 		}
 
 		// Verify if the certificate is issued for the requested app id
-		$certInfo = openssl_x509_parse(file_get_contents(__DIR__ . '/../../resources/nextcloud_announcements.crt'));
+		$certInfo = openssl_x509_parse(file_get_contents(__DIR__ . '/../../appinfo/certificate.crt'));
 		if(!isset($certInfo['subject']['CN'])) {
 			throw new \Exception('App with id nextcloud_announcements has a cert with no CN');
 		}
@@ -168,7 +168,7 @@ class Crawler extends TimedJob  {
 		$feedBody = $this->readFile('.rss');
 
 		// Check if the signature actually matches the downloaded content
-		$certificate = openssl_get_publickey(file_get_contents(__DIR__ . '/../../resources/nextcloud_announcements.crt'));
+		$certificate = openssl_get_publickey(file_get_contents(__DIR__ . '/../../appinfo/certificate.crt'));
 		$verified = (bool)openssl_verify($feedBody, base64_decode($signature), $certificate, OPENSSL_ALGO_SHA512);
 		openssl_free_key($certificate);
 


### PR DESCRIPTION
The file exists in the appinfo folder. Otherwhise this results in the following error:

```
file_get_contents(/var/www/html/apps/nextcloud_announcements/lib/Cron/../../resources/nextcloud_announcements.crt): failed to open stream: No such file or directory at /var/www/html/apps/nextcloud_announcements/lib/Cron/Crawler.php#161
```

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

cc @nickvergessen 