### PR TITLE
Add hint to settings

### DIFF
--- a/templates/admin.php
+++ b/templates/admin.php
@@ -28,6 +28,7 @@ script('nextcloud_announcements', 'admin');
 ?>
 <div id="nextcloud_announcements" class="section">
 	<h2 class="inlineblock"><?php p($l->t('Nextcloud announcements')); ?></h2>
+	<p class="settings-hint"><?php p($l->t('Shows the latest news of Nextcloud in your notifications.')); ?></p>
 
 	<p>
 		<input type="hidden" name="notification_groups" class="notification_groups" value="<?php p($_['groups']) ?>" style="width: 320px;" />


### PR DESCRIPTION
Adding more hints to settings, ref https://github.com/nextcloud/server/pull/4478 https://github.com/nextcloud/server/pull/4540

Please review @karlitschek @nickvergessen @MorrisJobke 

I would like to also clarify what exactly is shown. Like 
> Shows the latest news of Nextcloud in your notifications. This is only used for very important info like new versions and security fixes.

Or whatever it’s used for. That’s unclear in the readme and we should add it because initially it sounds like blogspam.