### PR TITLE
Move announcement settings from 'Additional' to 'Basic'

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -61,7 +61,7 @@ class Admin implements ISettings {
 	 * @return string the section ID, e.g. 'sharing'
 	 */
 	public function getSection() {
-		return 'additional';
+		return 'server';
 	}
 
 	/**


### PR DESCRIPTION
On a clean install via zip file, the settings of this app are the only ones which are in "Additional settings" which seems a bit unclean. So it’s moved to "Basic settings".

![announcements settings](https://user-images.githubusercontent.com/925062/53168047-0a180600-35da-11e9-8d53-770e1b103493.png)


As discussed @karlitschek, please check @nickvergessen :)