### PR TITLE
Randomize the interval.

### DIFF
--- a/lib/Cron/Crawler.php
+++ b/lib/Cron/Crawler.php
@@ -66,7 +66,11 @@ class Crawler extends TimedJob  {
 		$this->clientService = $clientService;
 
 		// Run once per day
-		$this->setInterval(24 * 60 * 60);
+		$interval = 24 * 60 * 60;
+		// Add random interval to spread load on server
+		$interval += random_int(0, 60) * 60;
+
+		$this->setInterval($interval);
 	}
 
 


### PR DESCRIPTION
This should help avoiding peaks on the serving server.
The feed still gets checked at least once every 25 hours. Which is
acceptable IMO.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>