### PR TITLE
Bugfix/noid/improve the notifications

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -109,14 +109,14 @@ class Notifier implements INotifier {
 
 				$isAdmin = $this->groupManager->isAdmin($notification->getUser());
 				if ($isAdmin) {
-					$action = $notification->createAction();
-					$action->setParsedLabel($l->t('Disable announcements'))
-						->setLink($this->url->linkToOCSRouteAbsolute('provisioning_api.AppsController.disable', ['app' => 'nextcloud_announcements']), IAction::TYPE_DELETE)
-						->setPrimary(false);
-					$notification->addParsedAction($action);
-
 					$groups = $this->config->getAppValue($this->appName, 'notification_groups', '');
 					if ($groups === '') {
+						$action = $notification->createAction();
+						$action->setParsedLabel($l->t('Disable announcements'))
+							->setLink($this->url->linkToOCSRouteAbsolute('provisioning_api.AppsController.disable', ['app' => 'nextcloud_announcements']), IAction::TYPE_DELETE)
+							->setPrimary(false);
+						$notification->addParsedAction($action);
+
 						$message .= "\n\n" . $l->t('(These announcements are only shown to administrators)');
 					}
 				}

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -101,6 +101,12 @@ class Notifier implements INotifier {
 				$notification->setParsedSubject($l->t('Nextcloud announcement'))
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath($this->appName, 'app-dark.svg')));
 
+				$action = $notification->createAction();
+				$action->setParsedLabel($l->t('Read more'))
+					->setLink($notification->getLink(), IAction::TYPE_WEB)
+					->setPrimary(true);
+				$notification->addParsedAction($action);
+
 				$isAdmin = $this->groupManager->isAdmin($notification->getUser());
 				if ($isAdmin) {
 					$action = $notification->createAction();

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -24,6 +24,7 @@
 namespace OCA\NextcloudAnnouncements\Notification;
 
 
+use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
@@ -41,16 +42,20 @@ class Notifier implements INotifier {
 	protected $l10nFactory;
 	/** @var IURLGenerator */
 	protected $url;
+	/** @var IConfig */
+	protected $config;
 	/** @var IGroupManager */
 	protected $groupManager;
 
 	public function __construct(string $appName,
 								IFactory $l10nFactory,
 								IURLGenerator $url,
+								IConfig $config,
 								IGroupManager $groupManager) {
 		$this->appName = $appName;
 		$this->l10nFactory = $l10nFactory;
 		$this->url = $url;
+		$this->config = $config;
 		$this->groupManager = $groupManager;
 	}
 
@@ -92,8 +97,8 @@ class Notifier implements INotifier {
 		switch ($notification->getSubject()) {
 			case self::SUBJECT:
 				$parameters = $notification->getSubjectParameters();
+				$message = $parameters[0];
 				$notification->setParsedSubject($l->t('Nextcloud announcement'))
-					->setParsedMessage($parameters[0])
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath($this->appName, 'app-dark.svg')));
 
 				$isAdmin = $this->groupManager->isAdmin($notification->getUser());
@@ -103,7 +108,14 @@ class Notifier implements INotifier {
 						->setLink($this->url->linkToOCSRouteAbsolute('provisioning_api.AppsController.disable', ['app' => 'nextcloud_announcements']), IAction::TYPE_DELETE)
 						->setPrimary(false);
 					$notification->addParsedAction($action);
+
+					$groups = $this->config->getAppValue($this->appName, 'notification_groups', '');
+					if ($groups === '') {
+						$message .= "\n\n" . $l->t('(These announcements are only shown to administrators)');
+					}
 				}
+
+				$notification->setParsedMessage($message);
 
 				return $notification;
 

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -24,8 +24,10 @@
 namespace OCA\NextcloudAnnouncements\Notification;
 
 
+use OCP\IGroupManager;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Notification\IAction;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 
@@ -35,22 +37,21 @@ class Notifier implements INotifier {
 
 	/** @var string */
 	protected $appName;
-
 	/** @var IFactory */
 	protected $l10nFactory;
-
 	/** @var IURLGenerator */
 	protected $url;
+	/** @var IGroupManager */
+	protected $groupManager;
 
-	/**
-	 * @param string $appName
-	 * @param IFactory $l10nFactory
-	 * @param IURLGenerator $url
-	 */
-	public function __construct($appName, IFactory $l10nFactory, IURLGenerator $url) {
+	public function __construct(string $appName,
+								IFactory $l10nFactory,
+								IURLGenerator $url,
+								IGroupManager $groupManager) {
 		$this->appName = $appName;
 		$this->l10nFactory = $l10nFactory;
 		$this->url = $url;
+		$this->groupManager = $groupManager;
 	}
 
 	/**
@@ -94,6 +95,15 @@ class Notifier implements INotifier {
 				$notification->setParsedSubject($l->t('Nextcloud announcement'))
 					->setParsedMessage($parameters[0])
 					->setIcon($this->url->getAbsoluteURL($this->url->imagePath($this->appName, 'app-dark.svg')));
+
+				$isAdmin = $this->groupManager->isAdmin($notification->getUser());
+				if ($isAdmin) {
+					$action = $notification->createAction();
+					$action->setParsedLabel($l->t('Disable announcements'))
+						->setLink($this->url->linkToOCSRouteAbsolute('provisioning_api.AppsController.disable', ['app' => 'nextcloud_announcements']), IAction::TYPE_DELETE)
+						->setPrimary(false);
+					$notification->addParsedAction($action);
+				}
 
 				return $notification;
 


### PR DESCRIPTION
> ![Bildschirmfoto von 2019-09-11 11-24-07](https://user-images.githubusercontent.com/213943/64686717-63b62400-d489-11e9-8a82-66d2c137d041.png)

* When the default settings are in place:
    + Show a note that it's only shown to administrators
    + Offer a button to immediately disable the app
* Added a primary button to open the announcement (needs to be removed when backporting to 16 and below, due to feature support)