### PR TITLE
Update openssl function to support PHP 8.0

### DIFF
--- a/lib/Cron/Crawler.php
+++ b/lib/Cron/Crawler.php
@@ -174,7 +174,11 @@ class Crawler extends TimedJob  {
 		// Check if the signature actually matches the downloaded content
 		$certificate = openssl_get_publickey(file_get_contents(__DIR__ . '/../../appinfo/certificate.crt'));
 		$verified = (bool)openssl_verify($feedBody, base64_decode($signature), $certificate, OPENSSL_ALGO_SHA512);
-		openssl_free_key($certificate);
+		
+		// PHP 8 automatically frees the key instance and deprecates the function
+           	if (PHP_VERSION_ID < 80000) {
+                openssl_free_key($pubkeyid);
+            	}
 
 		if (!$verified) {
 			// Signature does not match


### PR DESCRIPTION
Help fix https://github.com/nextcloud/server/issues/26552

```
{"reqId":"sumTIPnz2JqUcba0vEuQ","level":3,"time":"2021-04-13T20:15:06+00:00","remoteAddr":"","user":"--","app":"PHP","method":"","url":"--","message":{"Exception":"Error","Message":"Function openssl_free_key() is deprecated at /var/www/nextcloud/apps/nextcloud_announcements/lib/Cron/Crawler.php#177","Code":0,"Trace":[{"file":"/var/www/nextcloud/apps/nextcloud_announcements/lib/Cron/Crawler.php","line":177,"function":"onError","class":"OC\\Log\\ErrorHandler","type":"::"},{"file":"/var/www/nextcloud/apps/nextcloud_announcements/lib/Cron/Crawler.php","line":79,"function":"loadFeed","class":"OCA\\NextcloudAnnouncements\\Cron\\Crawler","type":"->"},{"file":"/var/www/nextcloud/lib/private/BackgroundJob/Job.php","line":52,"function":"run","class":"OCA\\NextcloudAnnouncements\\Cron\\Crawler","type":"->"},{"file":"/var/www/nextcloud/lib/private/BackgroundJob/TimedJob.php","line":59,"function":"execute","class":"OC\\BackgroundJob\\Job","type":"->"},{"file":"/var/www/nextcloud/cron.php","line":128,"function":"execute","class":"OC\\BackgroundJob\\TimedJob","type":"->"}],"File":"/var/www/nextcloud/lib/private/Log/ErrorHandler.php","Line":92,"CustomMessage":"--"},"userAgent":"--","version":"21.0.1.1","id":"607637dcaeed7"}
```