### PR TITLE
[stable24] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -945,12 +945,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "aa88708d8280ffd8498ccda9954d923a1da55c92"
+                "reference": "0b70fb7e206b0d774f092cc4e053bf6e8db96072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/aa88708d8280ffd8498ccda9954d923a1da55c92",
-                "reference": "aa88708d8280ffd8498ccda9954d923a1da55c92",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0b70fb7e206b0d774f092cc4e053bf6e8db96072",
+                "reference": "0b70fb7e206b0d774f092cc4e053bf6e8db96072",
                 "shasum": ""
             },
             "require": {
@@ -977,9 +977,10 @@
             ],
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
+                "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable24"
             },
-            "time": "2022-09-27T08:15:22+00:00"
+            "time": "2022-10-28T00:52:53+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency