### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
 	<summary>Nextcloud announcements brings the latest news of Nextcloud into your notifications</summary>
 	<description>Nextcloud announcements brings the latest news of Nextcloud into your notifications</description>
 	<version>7.0.0-dev.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Joas Schilling</author>
 	<namespace>NextcloudAnnouncements</namespace>
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	},
 	"name": "nextcloud/nextcloud_announcements",
 	"description": "nextcloud_announcements",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"config": {
 		"classmap-authoritative": true,
 		"optimize-autoloader": true,


### PR DESCRIPTION
unifying the license string using SPDX license identifier supported in info.xml since 31, so no issue given min-version is set to 35 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
