### PR TITLE
[stable34] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 25fc4c7e69e778e20bdc9eb0cc96367e block-merge-freeze.yml
 e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
-c5893d7af1998af66d22f8c171ff4448 lint-info-xml.yml
+023b664746d1f2e09a9aaaac772ff7f5 lint-info-xml.yml
 870b483dbcbca59479211270d61546dd lint-php-cs.yml
 ee2b04d185b82fe7dd6fe6d83c6c7b45 lint-php.yml
-07e60b2f304c749ee563f1256caf2793 phpunit-mysql.yml
+d676be1ed03142832d8e712962f5961c phpunit-mysql.yml
 3c4a096b3b7dbaef0f8e5190ffe13518 pr-feedback.yml
 20b5d0d45766e3793f19c9c0c8d05140 psalm.yml
 3975dc58817119d596a8f6ed190352ce reuse.yml

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: |
+            appinfo/
 
       - name: Download schema
         run: wget https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -68,6 +68,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
 
     name: MySQL ${{ matrix.mysql-versions }} PHP ${{ matrix.php-versions }} Nextcloud ${{ matrix.server-versions }}


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [lint-info-xml.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-info-xml.yml)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)