### PR TITLE
[stable32] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
-25fc4c7e69e778e20bdc9eb0cc96367e block-merge-freeze.yml
+acad44f3e99b665897766ce90374dd03 block-merge-freeze.yml
 e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
 43fd0c5fb704cabc5f11cdfaf513236d lint-info-xml.yml
 4b40dd0073e16f74dd04e6d49dcc043d lint-php-cs.yml
 cfb31e47b6e9ab65e76c89b028754a4e lint-php.yml
-8fab08ac7da700ee304af0bf3c18b3a3 phpunit-mysql.yml
+6d20bb9054bf13310aaa1bf98025b3d9 phpunit-mysql.yml
 d1821b8a816578070ed8fd018f321f6d pr-feedback.yml
 6dc046dfbca5dc65d938265c518fcac4 psalm.yml
 2dbec18233063b42f4d8e03bbb43671c reuse.yml
 a3440826636c0fd7c2d20b1de50363da update-nextcloud-ocp-approve-merge.yml
-f5632e6d28c6afca9d4d46131fb48d57 update-nextcloud-ocp.yml
+1919e2ff468e875aeeae5fd088d4ce1f update-nextcloud-ocp.yml

--- a/.github/workflows/block-merge-freeze.yml
+++ b/.github/workflows/block-merge-freeze.yml
@@ -54,4 +54,4 @@ jobs:
 
       - name: Run check
         if: ${{ env.server_ref != '' }}
-        run: cat version.php | grep 'OC_VersionString' | grep -i -v 'RC'
+        run: cat version.php | grep 'OC_VersionString' | grep -i -v -E '(\.0\.0 RC[3-9]|\.[1-9][0-9]* RC)'

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -44,7 +44,7 @@ jobs:
       src: ${{ steps.changes.outputs.src}}
 
     steps:
-      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: changes
         continue-on-error: true
         with:

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         branches:
           - ${{ github.event.repository.default_branch }}
+          - 'stable35'
           - 'stable34'
           - 'stable33'
           - 'stable32'


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [block-merge-freeze.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/block-merge-freeze.yml)
- 🆙 Updated [phpunit-mysql.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/phpunit-mysql.yml)
- 🆙 Updated [update-nextcloud-ocp.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/update-nextcloud-ocp.yml)